### PR TITLE
OP-TEE benchmark: initial benchmark app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+host/hello_world
+GPATH
+GRTAGS
+GSYMS
+GTAGS
+*.cmd
+*.d
+*.dmp
+*.elf
+*.lds
+*.map
+*.o
+*.png
+*.swp
+*.ta
+cscope.*

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+CC      = $(CROSS_COMPILE)gcc
+LD      = $(CROSS_COMPILE)ld
+AR      = $(CROSS_COMPILE)ar
+NM      = $(CROSS_COMPILE)nm
+OBJCOPY = $(CROSS_COMPILE)objcopy
+OBJDUMP = $(CROSS_COMPILE)objdump
+READELF = $(CROSS_COMPILE)readelf
+
+OBJS	:= main.o benchmark_aux.o
+
+CFLAGS += -Wall -I$(TEEC_EXPORT)/include\
+		-I./include -I$(TEEC_INTERNAL_INCLUDES)/include
+#Add/link other required libraries here
+LDADD += -lm -lteec -lpthread -L$(TEEC_EXPORT)/lib
+CROSS_COMPILE="$(HOST_CROSS_COMPILE)"
+
+BINARY = benchmark
+
+.PHONY: all
+all: $(BINARY)
+
+$(BINARY): $(OBJS)
+	$(CC) $(LDADD) $(OBJS) -o $(BINARY)
+
+.PHONY: clean
+clean:
+	rm -f $(OBJS) $(BINARY)

--- a/benchmark_aux.c
+++ b/benchmark_aux.c
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2016, Linaro Limited
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <libgen.h>
+#include <linux/limits.h>
+#include <math.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "benchmark_aux.h"
+
+/* Misc auxilary functions */
+void tee_errx(const char *msg, TEEC_Result res)
+{
+	fprintf(stderr, "%s: 0x%08x\n", msg, res);
+	exit(1);
+}
+
+void tee_check_res(TEEC_Result res, const char *errmsg)
+{
+	if (res != TEEC_SUCCESS)
+		tee_errx(errmsg, res);
+}
+
+const char *bench_str_src(uint64_t source)
+{
+	switch (source) {
+	case TEE_BENCH_CORE:
+		return "CORE";
+	case TEE_BENCH_KMOD:
+		return "KMOD";
+	case TEE_BENCH_CLIENT:
+		return "CLIENT";
+	case TEE_BENCH_UTEE:
+		return "UTEE";
+	case TEE_BENCH_DUMB_TA:
+		return "DUMB_TA";
+	default:
+		return "???";
+	}
+}
+
+void print_line(void)
+{
+		int n = 115;
+
+		while (n-- > 0)
+			printf("=");
+		printf("\n");
+}
+
+void alloc_argv(int argc, char *argv[], char **new_argv[])
+{
+	char *res, *base;
+	char path[PATH_MAX];
+	char **testapp_argv;
+
+	res = realpath(argv[1], path);
+	if (!res)
+		_exit(EXIT_FAILURE);
+
+	*new_argv = malloc(argc * sizeof(void *));
+	if (!(*new_argv))
+		_exit(EXIT_FAILURE);
+
+	testapp_argv = *new_argv;
+	testapp_argv[argc-1] = NULL;
+	base = basename(path);
+
+	testapp_argv[0] = malloc(strlen(base) + 1);
+	if (!testapp_argv[0])
+		_exit(EXIT_FAILURE);
+
+	memcpy(testapp_argv[0], base, strlen(base) + 1);
+
+	for (int i = 2; i < argc; i++) {
+		size_t length = strlen(argv[i]) + 1;
+
+		testapp_argv[i - 1] = malloc(length);
+		if (!testapp_argv[i - 1])
+			_exit(EXIT_FAILURE);
+
+		memcpy(testapp_argv[i-1], argv[i], length);
+	}
+}
+
+void dealloc_argv(int new_argc, char **new_argv)
+{
+	for (int i = 0; i < new_argc; ++i)
+		free(new_argv[i]);
+
+	free(new_argv);
+}
+
+uint32_t get_cores(void)
+{
+	return sysconf(_SC_NPROCESSORS_ONLN);
+}

--- a/benchmark_aux.h
+++ b/benchmark_aux.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2016, Linaro Limited
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef BENCHMARK_AUX_H
+#define BENCHMARK_AUX_H
+
+#include <tee_client_api.h>
+#include <tee_bench.h>
+
+/* tee error code checking etc */
+void tee_errx(const char *msg, TEEC_Result res);
+void tee_check_res(TEEC_Result res, const char *errmsg);
+
+/* misc aux print functions */
+const char *bench_str_src(uint64_t source);
+void print_line(void);
+
+/* argv alloc/dealloc */
+void alloc_argv(int argc, char *argv[], char **new_argv[]);
+void dealloc_argv(int new_argc, char **new_argv);
+
+/* get amount of cores */
+uint32_t get_cores(void);
+#endif /* BENCHMARK_AUX_H */

--- a/main.c
+++ b/main.c
@@ -1,0 +1,306 @@
+/*
+ * Copyright (c) 2016, Linaro Limited
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include <limits.h>
+#include <libgen.h>
+#include <pthread.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "benchmark_aux.h"
+
+#define STAT_AMOUNT 5
+#define TSFILE_NAME_SUFFIX			".ts"
+
+#define RING_SUCCESS	0
+#define RING_BADPARM	-1
+#define RING_NODATA		-2
+
+static const TEEC_UUID pta_benchmark_uuid = PTA_BENCHMARK_UUID;
+struct tee_ts_global *bench_ts_global;
+static bool is_running;
+
+static TEEC_SharedMemory ts_buf_shm = {
+		.flags = TEEC_MEM_INPUT | TEEC_MEM_OUTPUT
+};
+
+static TEEC_Context ctx;
+static TEEC_Session sess;
+
+static void open_bench_pta(void)
+{
+	TEEC_Result res;
+	uint32_t err_origin;
+
+	res = TEEC_InitializeContext(NULL, &ctx);
+	tee_check_res(res, "TEEC_InitializeContext");
+
+	res = TEEC_OpenSession(&ctx, &sess, &pta_benchmark_uuid,
+			TEEC_LOGIN_PUBLIC, NULL, NULL, &err_origin);
+	tee_check_res(res, "TEEC_OpenSession");
+}
+
+static void close_bench_pta(void)
+{
+	/* release benchmark timestamp shm */
+	TEEC_ReleaseSharedMemory(&ts_buf_shm);
+	TEEC_CloseSession(&sess);
+	TEEC_FinalizeContext(&ctx);
+}
+
+static void init_ts_global(void *ts_global, uint32_t cores)
+{
+	struct tee_ts_cpu_buf *cpu_buf;
+
+	/* init global timestamp buffer */
+	bench_ts_global = (struct tee_ts_global *)ts_global;
+	bench_ts_global->cores = cores;
+
+	/* init per-cpu timestamp buffers */
+	for (int i = 0; i < cores; i++) {
+		cpu_buf = &bench_ts_global->cpu_buf[i];
+		memset(cpu_buf, 0, sizeof(struct tee_ts_cpu_buf));
+	}
+}
+
+static void register_bench_buf(uint32_t cores)
+{
+	TEEC_Result res;
+	TEEC_Operation op = { 0 };
+	uint32_t ret_orig;
+
+	ts_buf_shm.size = sizeof(struct tee_ts_global) +
+			sizeof(struct tee_ts_cpu_buf) * cores;
+
+	/* allocate global timestamp buffer */
+	res = TEEC_AllocateSharedMemory(&ctx, &ts_buf_shm);
+	tee_check_res(res, "TEEC_AllocateSharedMemory");
+
+	init_ts_global(ts_buf_shm.buffer, cores);
+
+	op.paramTypes = TEEC_PARAM_TYPES(TEEC_MEMREF_PARTIAL_INOUT,
+			TEEC_NONE, TEEC_NONE, TEEC_NONE);
+	op.params[0].memref.parent = &ts_buf_shm;
+
+	TEEC_InvokeCommand(&sess, BENCHMARK_CMD_REGISTER_MEMREF,
+					&op, &ret_orig);
+	tee_check_res(res, "TEEC_InvokeCommand");
+}
+
+static void unregister_bench(void)
+{
+	TEEC_Result res;
+	TEEC_Operation op = { 0 };
+	uint32_t ret_orig;
+
+	op.paramTypes = TEEC_PARAM_TYPES(TEEC_NONE,
+					TEEC_NONE, TEEC_NONE, TEEC_NONE);
+
+	res = TEEC_InvokeCommand(&sess, BENCHMARK_CMD_UNREGISTER,
+					&op, &ret_orig);
+	tee_check_res(res, "TEEC_InvokeCommand");
+}
+
+static void usage(char *progname)
+{
+	fprintf(stderr, "Call latency benchmark tool for OP-TEE\n\n");
+	fprintf(stderr, "Usage:\n");
+	fprintf(stderr, "  %s -h\n", progname);
+	fprintf(stderr, "  %s host_app [host_app_args]\n", progname);
+	fprintf(stderr, "Options:\n");
+	fprintf(stderr, "  -h              Print this help and exit\n");
+	fprintf(stderr, "  host_app        Path to host app to benchmark\n");
+	fprintf(stderr, "  host_app_args   Original host app args\n");
+}
+
+static int timestamp_pop(struct tee_ts_cpu_buf *cpu_buf,
+						struct tee_time_st *ts)
+{
+	uint64_t ts_tail;
+
+	if (!cpu_buf && !ts)
+		return RING_BADPARM;
+
+	if (cpu_buf->tail >= cpu_buf->head)
+		return RING_NODATA;
+
+	ts_tail = cpu_buf->tail++;
+	*ts = cpu_buf->stamps[ts_tail & TEE_BENCH_MAX_MASK];
+
+	return 0;
+}
+
+static void *ts_consumer(void *arg)
+{
+	int i, ret;
+	bool ts_received = false;
+	uint32_t cores;
+	struct tee_time_st ts_data;
+	FILE *ts_file;
+	char *tsfile_path;
+
+	tsfile_path = arg;
+	if (!tsfile_path)
+		goto exit;
+
+	cores = get_cores();
+	if (!cores)
+		goto exit;
+
+	ts_file = fopen(tsfile_path, "w");
+	if (!ts_file)
+		goto exit;
+
+	while (is_running) {
+		ts_received = false;
+		for (i = 0; i < cores; i++) {
+			ret = timestamp_pop(&bench_ts_global->cpu_buf[i],
+						&ts_data);
+			if (!ret) {
+				ts_received = true;
+				fprintf(ts_file, "%ld\t%lld\t0x%"
+						PRIx64 "\t%s\n",
+						i, ts_data.cnt, ts_data.addr,
+						bench_str_src(ts_data.src));
+			}
+		}
+
+		if (!ts_received)
+			if (is_running)
+				sched_yield();
+			else
+				goto file_close;
+	}
+
+file_close:
+	fclose(ts_file);
+exit:
+	return NULL;
+}
+
+int main(int argc, char *argv[])
+{
+	int i;
+	int status;
+	pid_t pid;
+	char testapp_path[PATH_MAX];
+	char **testapp_argv;
+	char *res;
+	char *tsfile_path;
+	uint32_t cores;
+	pthread_t consumer_thread;
+
+	if (argc == 1) {
+		usage(argv[0]);
+		return 0;
+	}
+
+	/* Parse command line */
+	for (i = 1; i < argc; i++) {
+		if (!strcmp(argv[i], "-h")) {
+			usage(argv[0]);
+			return 0;
+		}
+	}
+
+	printf("1. Opening Benchmark Static TA...\n");
+	open_bench_pta();
+
+	cores = get_cores();
+	if (!cores)
+		tee_errx("Receiving amount of active cores failed",
+					EXIT_FAILURE);
+
+	printf("2. Allocating per-core buffers, cores detected = %d\n",
+					cores);
+	register_bench_buf(cores);
+
+	res = realpath(argv[1], testapp_path);
+	if (!res)
+		tee_errx("Failed to get realpath", EXIT_FAILURE);
+
+	alloc_argv(argc, argv, &testapp_argv);
+
+	printf("3. Starting origin host app %s ...\n", testapp_path);
+
+	/* fork/exec here */
+	pid = fork();
+
+	if (pid == -1) {
+		tee_errx("fork() failed", EXIT_FAILURE);
+	} else if (pid > 0) {
+		is_running = 1;
+
+		tsfile_path = malloc(strlen(testapp_path) +
+					strlen(TSFILE_NAME_SUFFIX) + 1);
+		if (!tsfile_path)
+			return 1;
+
+		tsfile_path[0] = '\0';
+		strcat(tsfile_path, testapp_path);
+		strcat(tsfile_path, TSFILE_NAME_SUFFIX);
+
+		printf("Dumping timestamps to %s ...\n", tsfile_path);
+		print_line();
+
+		if (pthread_create(&consumer_thread, NULL,
+				ts_consumer, tsfile_path)) {
+			fprintf(stderr, "Error creating ts consumer thread\n");
+			return 1;
+		}
+		/* wait for child app exits */
+		waitpid(pid, &status, 0);
+		is_running = 0;
+
+		/* wait for our consumer thread terminate */
+		if (pthread_join(consumer_thread, NULL)) {
+			fprintf(stderr, "Error joining thread\n");
+			return 2;
+		}
+	}
+	else {
+		execvp(testapp_path, testapp_argv);
+		tee_errx("execve() failed", EXIT_FAILURE);
+	}
+
+	printf("4. Done benchmark\n");
+
+	dealloc_argv(argc-1, testapp_argv);
+	unregister_bench();
+	close_bench_pta();
+	return 0;
+}


### PR DESCRIPTION
Related PRs:

Benchmark app:
https://github.com/linaro-swg/optee_benchmark/pull/1

Changes in OP-TEE
https://github.com/linaro-swg/linux/pull/38
https://github.com/OP-TEE/build/pull/124
https://github.com/OP-TEE/optee_os/pull/1365
https://github.com/OP-TEE/optee_client/pull/79

Dedicated repo manifest (for testing):
```
repo init -u https://github.com/igoropaniuk/manifest.git -m qemu_v7_benchmark.xml -b benchmark
```

Invocation:
```
# benchmark client_app [client_app params]
```

Example:
```
# benchmark ./xtest 1001
```
Signed-off-by: Igor Opaniuk <igor.opaniuk@linaro.org>