### PR TITLE
Fix compilation errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-host/hello_world
+benchmark
 GPATH
 GRTAGS
 GSYMS

--- a/Makefile
+++ b/Makefile
@@ -6,13 +6,11 @@ OBJCOPY = $(CROSS_COMPILE)objcopy
 OBJDUMP = $(CROSS_COMPILE)objdump
 READELF = $(CROSS_COMPILE)readelf
 
-OBJS	:= main.o benchmark_aux.o
+OBJS := main.o benchmark_aux.o
 
-CFLAGS += -Wall -I$(TEEC_EXPORT)/include\
-		-I./include -I$(TEEC_INTERNAL_INCLUDES)/include
+CFLAGS += -Wall -Wextra -Werror -I$(TEEC_EXPORT)/include -I$(TEEC_INTERNAL_INCLUDES)/include
 #Add/link other required libraries here
 LDADD += -lm -lteec -lpthread -L$(TEEC_EXPORT)/lib
-CROSS_COMPILE="$(HOST_CROSS_COMPILE)"
 
 BINARY = benchmark
 
@@ -20,7 +18,7 @@ BINARY = benchmark
 all: $(BINARY)
 
 $(BINARY): $(OBJS)
-	$(CC) $(LDADD) $(OBJS) -o $(BINARY)
+	$(CC) $(LDADD) -o $@ $^
 
 .PHONY: clean
 clean:

--- a/main.c
+++ b/main.c
@@ -84,6 +84,7 @@ static void close_bench_pta(void)
 
 static void init_ts_global(void *ts_global, uint32_t cores)
 {
+	unsigned int i;
 	struct tee_ts_cpu_buf *cpu_buf;
 
 	/* init global timestamp buffer */
@@ -91,7 +92,7 @@ static void init_ts_global(void *ts_global, uint32_t cores)
 	bench_ts_global->cores = cores;
 
 	/* init per-cpu timestamp buffers */
-	for (int i = 0; i < cores; i++) {
+	for (i = 0; i < cores; i++) {
 		cpu_buf = &bench_ts_global->cpu_buf[i];
 		memset(cpu_buf, 0, sizeof(struct tee_ts_cpu_buf));
 	}
@@ -166,7 +167,8 @@ static int timestamp_pop(struct tee_ts_cpu_buf *cpu_buf,
 
 static void *ts_consumer(void *arg)
 {
-	int i, ret;
+	unsigned int i;
+	int ret;
 	bool ts_received = false;
 	uint32_t cores;
 	struct tee_time_st ts_data;
@@ -192,18 +194,19 @@ static void *ts_consumer(void *arg)
 						&ts_data);
 			if (!ret) {
 				ts_received = true;
-				fprintf(ts_file, "%ld\t%lld\t0x%"
+				fprintf(ts_file, "%u\t%lld\t0x%"
 						PRIx64 "\t%s\n",
 						i, ts_data.cnt, ts_data.addr,
 						bench_str_src(ts_data.src));
 			}
 		}
 
-		if (!ts_received)
+		if (!ts_received) {
 			if (is_running)
 				sched_yield();
 			else
 				goto file_close;
+		}
 	}
 
 file_close:


### PR DESCRIPTION
The quotes within the Makefile would cause errors like "arm-gnueabihf-gcc not found".

I've taken this opportunity to fix compiler warnings and add "-Wextra -Werror". Hope that's OK.

---


FYI, when running the benchmark:
> ./optee_benchmark/benchmark aes-perf/out/aes-perf/aes-perf

I get this error:
> 4. Done benchmark
> TEEC_InvokeCommand: 0xffff000a

Couldn't figure out why though. Maybe a change in the API?