### PR TITLE
Fix compilation error and refine Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,25 +5,26 @@ NM      = $(CROSS_COMPILE)nm
 OBJCOPY = $(CROSS_COMPILE)objcopy
 OBJDUMP = $(CROSS_COMPILE)objdump
 READELF = $(CROSS_COMPILE)readelf
+O      ?= $(CURDIR)/out
+OUT_DIR = $(O)
 
 .PHONY: all
 all: libyaml benchmark
 
 .PHONY: clean
-clean: libyaml-clean
-	rm -f $(OBJS) benchmark
 ################################################################################
 # libYAML
 ################################################################################
 LIBYAML_FLAGS ?= CROSS_COMPILE=$(CROSS_COMPILE)
 LIBYAML_SRC_DIR = $(CURDIR)/libyaml
-LIBYAML_OUT_DIR = $(LIBYAML_SRC_DIR)/out
+LIBYAML_OUT_DIR = $(OUT_DIR)/libyaml/out
 
 .PHONY: libyaml
 libyaml:
+	$(AT)test -d $(LIBYAML_OUT_DIR) || mkdir -p $(LIBYAML_OUT_DIR)
 	cd $(LIBYAML_SRC_DIR) && ./bootstrap && \
 	./configure --host=$(MULTIARCH) \
-	--prefix=$(LIBYAML_SRC_DIR)/out CC=$(CC) && \
+	--prefix=$(LIBYAML_OUT_DIR) CC=$(CC) && \
 	$(MAKE) && $(MAKE) install
 
 .PHONY: libyaml-clean
@@ -34,13 +35,24 @@ libyaml-clean:
 ################################################################################
 # benchmark_app
 ################################################################################
-OBJS := main.o benchmark_aux.o
+SRCS := main.c benchmark_aux.c
+OBJS := $(patsubst %.c,$(OUT_DIR)/%.o, $(SRCS))
 
 CFLAGS += -Wall -Wextra -Werror -I$(TEEC_EXPORT)/include \
 		  -I$(TEEC_INTERNAL_INCLUDES)/include -I$(LIBYAML_OUT_DIR)/include
 #Add/link other required libraries here
 LDADD += -lm -lteec -lyaml -lpthread \
 		 -L$(TEEC_EXPORT)/lib -L$(LIBYAML_OUT_DIR)/lib
+$(OBJS) : libyaml
 
-benchmark: $(OBJS)
+benchmark: $(OUT_DIR)/benchmark
+
+$(OUT_DIR)/%.o: %.c
+	$(AT)test -d $(OUT_DIR) || mkdir -p $(OUT_DIR)
+	$(CC) $(CFLAGS) -c $< -o $@
+
+$(OUT_DIR)/benchmark: $(OBJS)
 	$(CC) $(LDADD) -o $@ $^
+
+clean: libyaml-clean
+	rm -rf $(OUT_DIR)

--- a/benchmark_aux.c
+++ b/benchmark_aux.c
@@ -77,6 +77,7 @@ void alloc_argv(int argc, char *argv[], char **new_argv[])
 	char *res, *base;
 	char path[PATH_MAX];
 	char **testapp_argv;
+	int i;
 
 	res = realpath(argv[1], path);
 	if (!res)
@@ -96,7 +97,7 @@ void alloc_argv(int argc, char *argv[], char **new_argv[])
 
 	memcpy(testapp_argv[0], base, strlen(base) + 1);
 
-	for (int i = 2; i < argc; i++) {
+	for (i = 2; i < argc; i++) {
 		size_t length = strlen(argv[i]) + 1;
 
 		testapp_argv[i - 1] = malloc(length);
@@ -109,7 +110,8 @@ void alloc_argv(int argc, char *argv[], char **new_argv[])
 
 void dealloc_argv(int new_argc, char **new_argv)
 {
-	for (int i = 0; i < new_argc; ++i)
+	int i;
+	for (i = 0; i < new_argc; ++i)
 		free(new_argv[i]);
 
 	free(new_argv);


### PR DESCRIPTION
Loop initial declarations are only allowed in C99 or C11 mode.
Add $(O) to support output targets to special directory.