### PR TITLE
[RFC][WIP]analyze: add initial skelethon

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,105 @@
-# optee_benchmark
-OP-TEE Latency benchmark application
+# OP-TEE Benchmark application
+## Contents
+1. [Introduction](#1-introduction)
+2. [Implementation details](#2-implementation-details)
+3. [Generating latency data](#3-generating-latency-data)
+4. [Analyzing results](#4-analyzing-results)
+
+## 1. Introduction
+
+This README contains information about examples of usage
+and implementation details of benchmark application.
+
+For a generic description of benchmark feature, its components in OP-TEE OS
+core, Linux TEE driver and libteec, please check [optee_benchmark.md].
+
+---
+
+## 2. Implementation details
+
+Benchmark application consists of two parts:
+- **Benchmark Client Application**, which is mainly used to generate latency
+  data. It should be invoked on a destination SoC.
+- **Benchmark analyze application**, which is used to analyze benchmark latency
+  data. We recommend to use it on the same PC, where OP-TEE and related
+  components were built, otherwise you won't receive proper translations of
+  addresses to filenames and line numbers
+
+## 2.1 Benchmark CA
+
+## 2.2 Analyze application
+`analyze.py` supports both Python 2 and 3. If you intend to use Python 2 or
+any other version >=3.4, you should install in advance back-ported
+`enum34` and `pathlib` packages using `pip` or `easy_install` package managers
+(depends on your preferance).
+
+```bash
+$ pip2 install enum34
+$ pip2 install pathlib
+```
+
+All logic for analyzing specific benchmark cases are stored in
+`analyze/benchcases.py` file. If you want to add your own case, you have to
+implement just one function which accepts as a param `TimestampParser` iterator,
+which helps to access all parsed set of timestamps with auxilary data from the
+timestamp dump file.
+
+Each `Timestamp` includes such information:
+- Counter value
+- Subsystem, where timestamp was generated
+- Core: identifies core id, where thread was running when timestamp had been
+  generated.
+- Address in subsystem, where timestamp was generated from.
+- Source file and line for address: `Timestamp` instance can automatically
+  resolve these values from symbol files, provided in `analyze/config.py`
+- Payload (not standartized). It could contain such values, like:
+    - Session ID: to distinguish one TEE session from another.
+
+If you want to contribute patches, you	should check if they follow PEP8
+style guide before creating any pull requests.
+
+---
+
+## 3. Generating latency data
+Before running any benchmarks, OP-TEE OS and other compoments should be built
+with `CFG_TEE_BENCHMARK` flag enabled. Check [optee_benchmark] for additional
+details.
+
+To collect benchmark data, you should invoke `benchmark`app and supply it with
+a path regular CA you won't to benchmark as a param.
+
+```bash
+$ benchmark client_app [client_app params]
+```
+
+When CA finishes its execution, `benchmark` will create
+`<client_app>.ts` timestamp data file by the same path, where original CA is
+stored.
+
+Check example:
+
+```bash
+$ benchmark /bin/xtest -l 15
+```
+After `xtest` successfully finishes running, `/bin/xtest.ts` will be created.
+
+---
+
+## 4. Analyzing results
+
+Basically, you can receive all possible params for `analyze.py` just by
+requesting internal help:
+
+```bash
+$ ./analyze.py -h
+```
+
+Example of analyzing client to tee benchmark case (using `-c` you specify a
+benchmark case; `optee_example_hello_world.ts` is file containing latency data
+generated in section 3):
+
+```bash
+$ ./analyze.py -c client2tee ../optee_example_hello_world.ts
+```
+
+[optee_benchmark]: https://github.com/OP-TEE/optee_os/blob/master/documentation/benchmark.md

--- a/analyze.py
+++ b/analyze.py
@@ -1,17 +1,20 @@
 #!/usr/bin/env python
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Copyright (c) 2017, Linaro Limited
+#
 
-import argparse
-from pathlib import Path
 import sys
 
 # path to all benchmark modules
 sys.path.append("analyze/")
-if sys.version_info[0] < 3:
-    raise "Python 3 should be used to run this script"
 
+import argparse
 import config
-from timestamp import *
+
 from benchcases import *
+from pathlib import Path
+from timestamp import *
 
 # handle params
 arg_parser = argparse.ArgumentParser()
@@ -23,13 +26,14 @@ args = arg_parser.parse_args()
 
 try:
     if not (args.filename and Path(args.filename).is_file()):
-        raise RuntimeError("Wrong path to timestamp dump file")
+        raise RuntimeError("Cannot find file: {}.".format(args.filename))
 
     ts_parser = TimestampParser(Path(args.filename))
 
+# run benchmark case
     if args.case:
         cases[args.case](ts_parser)
     else:
-        bench_case = 0
+        cases[0](ts_parser)
 except Exception as inst:
     print("Error occured: " + str(inst))

--- a/analyze.py
+++ b/analyze.py
@@ -5,6 +5,7 @@
 #
 
 import sys
+import traceback
 
 # path to all benchmark modules
 sys.path.append("analyze/")
@@ -28,8 +29,10 @@ try:
     if not (args.filename and Path(args.filename).is_file()):
         raise RuntimeError("Cannot find file: {}.".format(args.filename))
 
+    print("Loading dump file...")
     ts_parser = TimestampParser(Path(args.filename))
 
+    print("Analyzing {} benchmark case...".format(str(args.case)))
 # run benchmark case
     if args.case:
         cases[args.case](ts_parser)
@@ -37,3 +40,4 @@ try:
         cases[0](ts_parser)
 except Exception as inst:
     print("Error occured: " + str(inst))
+    traceback.print_exc(file=sys.stdout)

--- a/analyze.py
+++ b/analyze.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+
+import argparse
+from pathlib import Path
+import sys
+
+# path to all benchmark modules
+sys.path.append("analyze/")
+if sys.version_info[0] < 3:
+    raise "Python 3 should be used to run this script"
+
+import config
+from timestamp import *
+from benchcases import *
+
+# handle params
+arg_parser = argparse.ArgumentParser()
+arg_parser.add_argument("filename", help="File with timestamps")
+arg_parser.add_argument("-c", "--case", type=BenchmarkCase,
+                        choices=list(BenchmarkCase),
+                        help="Specify the benchmark case you want to analyze")
+args = arg_parser.parse_args()
+
+try:
+    if not (args.filename and Path(args.filename).is_file()):
+        raise RuntimeError("Wrong path to timestamp dump file")
+
+    ts_parser = TimestampParser(Path(args.filename))
+
+    if args.case:
+        cases[args.case](ts_parser)
+    else:
+        bench_case = 0
+except Exception as inst:
+    print("Error occured: " + str(inst))

--- a/analyze/benchcases.py
+++ b/analyze/benchcases.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+
+from enum import Enum
+
+__all__ = ['BenchmarkCase', 'cases']
+
+
+class BenchmarkCase(Enum):
+    CLIENT2TEE = 'client2tee'
+    KMOD2TEE = 'kernel2tee'
+
+    def __str__(self):
+        return str(self.value)
+
+
+def benchmark_client2tee(timestamp_parser):
+    print("Analyzing client2tee")
+    raise NotImplementedError
+
+
+def benchmark_kernelmode2tee(timestamp_parser):
+    print("Analyzing kernel2tee")
+    raise NotImplementedError
+
+
+cases = {
+         BenchmarkCase.CLIENT2TEE: benchmark_client2tee,
+         BenchmarkCase.KMOD2TEE: benchmark_kernelmode2tee
+         }

--- a/analyze/benchcases.py
+++ b/analyze/benchcases.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # SPDX-License-Identifier: BSD-2-Clause
 #
-# Copyright (c) 2017, Linaro Limited
+# Copyright (c) 2018, Linaro Limited
 #
 
 from enum import Enum
@@ -27,8 +27,10 @@ class BenchmarkCase(Enum):
 
 
 def benchmark_client2tee(timestamp_parser):
-    raise NotImplementedError(
-        "{} is not implemented".format(whoami()))
+    # raise NotImplementedError(
+    #    "{} is not implemented".format(whoami()))
+    for ts in timestamp_parser:
+        print("address = {}.".format(str(ts.address)))
 
 
 def benchmark_kernelmode2tee(timestamp_parser):

--- a/analyze/benchcases.py
+++ b/analyze/benchcases.py
@@ -1,8 +1,21 @@
 #!/usr/bin/env python
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Copyright (c) 2017, Linaro Limited
+#
 
 from enum import Enum
+import sys
 
 __all__ = ['BenchmarkCase', 'cases']
+
+
+if __name__ == '__main__':
+    sys.exit("This source file should be used only as a module")
+
+
+def whoami():
+        return sys._getframe(1).f_code.co_name
 
 
 class BenchmarkCase(Enum):
@@ -14,13 +27,13 @@ class BenchmarkCase(Enum):
 
 
 def benchmark_client2tee(timestamp_parser):
-    print("Analyzing client2tee")
-    raise NotImplementedError
+    raise NotImplementedError(
+        "{} is not implemented".format(whoami()))
 
 
 def benchmark_kernelmode2tee(timestamp_parser):
-    print("Analyzing kernel2tee")
-    raise NotImplementedError
+    raise NotImplementedError(
+        "{} is not implemented".format(whoami()))
 
 
 cases = {

--- a/analyze/config.py
+++ b/analyze/config.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Copyright (c) 2017, Linaro Limited
+#
 
 import sys
 from pathlib import Path
 from timestamp import Subsystem
-
-if sys.version_info[0] < 3:
-    raise "Python 3 should be used to run this script"
 
 if __name__ == '__main__':
     sys.exit("This source file should be used only as a module")

--- a/analyze/config.py
+++ b/analyze/config.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # SPDX-License-Identifier: BSD-2-Clause
 #
-# Copyright (c) 2017, Linaro Limited
+# Copyright (c) 2018, Linaro Limited
 #
 
 import sys
@@ -12,10 +12,10 @@ if __name__ == '__main__':
     sys.exit("This source file should be used only as a module")
 
 subsystem_paths = {Subsystem.LIBTEEC:
-                   Path('../../optee_client/out/libteec/libteec.so.1.0'),
+                   Path('../optee_client/out/libteec/libteec.so.1.0'),
                    Subsystem.LINUXMOD:
-                   Path('../../linux/vmlinux'),
+                   Path('../linux/vmlinux'),
                    Subsystem.OPTEECORE:
-                   Path('../../optee_os/out/arm/core/tee.bin')}
+                   Path('../optee_os/out/arm/core/tee.elf')}
 
-addr2line = Path('/usr/bin/addr2line')
+addr2line = Path('../toolchains/aarch32/bin/arm-linux-gnueabihf-addr2line')

--- a/analyze/config.py
+++ b/analyze/config.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+
+import sys
+from pathlib import Path
+from timestamp import Subsystem
+
+if sys.version_info[0] < 3:
+    raise "Python 3 should be used to run this script"
+
+if __name__ == '__main__':
+    sys.exit("This source file should be used only as a module")
+
+subsystem_paths = {Subsystem.LIBTEEC:
+                   Path('../../optee_client/out/libteec/libteec.so.1.0'),
+                   Subsystem.LINUXMOD:
+                   Path('../../linux/vmlinux'),
+                   Subsystem.OPTEECORE:
+                   Path('../../optee_os/out/arm/core/tee.bin')}
+
+addr2line = Path('/usr/bin/addr2line')

--- a/analyze/timestamp.py
+++ b/analyze/timestamp.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Copyright (c) 2017, Linaro Limited
+#
 
 import config
 import io
@@ -30,7 +34,7 @@ class Addr2Line(object):
                                         "-e", str(binary)],
                                         stdin=subprocess.PIPE,
                                         stdout=subprocess.PIPE)
-        # and lets use buffered input
+        # and let's use buffered input
         self.stdin_wrapper = io.TextIOWrapper(self.process.stdin,
                                               'utf-8')
 
@@ -69,7 +73,7 @@ class Timestamp(object):
     Able to parse address of binary file of subsystem and provide
     actual source file and line
     """
-    __symbol_parsers = {}
+    _symbol_parsers = {}
 
     def __init__(self, core, counter, subsystem, address, payload):
         self.core = core
@@ -81,21 +85,21 @@ class Timestamp(object):
         self.address = long(address)
         self.payload = payload
 
-        self.__parse_addr()
+        self._parse_addr()
 
-    def __parse_addr(self):
+    def _parse_addr(self):
         if self.address and self.subsystem:
             if self.subsystem not in self.__symbol_parsers:
-                self.__symbol_parsers[self.subsystem, Addr2Line(
+                self._symbol_parsers[self.subsystem, Addr2Line(
                     config.subsystem_paths[self.subsystem])]
 
             (self.filename, self.line) = \
-                self.__symbol_parsers[self.subsystem].lookup(self.address)
+                self._symbol_parsers[self.subsystem].lookup(self.address)
 
         else:
             raise ValueError('Timestamp address/subsystem isn\'t initialized')
 
-    def __parse_payload(self):
+    def _parse_payload(self):
         raise NotImplementedError
 
 
@@ -103,7 +107,7 @@ class TimestampParser(object):
     def __init__(self, yaml_path):
         if not (isinstance(yaml_path, Path) and
                 yaml_path.is_file()):
-            raise ValueError
+            raise RuntimeError("Cannot find file: {}.".format(str(yaml_path)))
 
         self.i = 0
         self.yaml_path = yaml_path

--- a/analyze/timestamp.py
+++ b/analyze/timestamp.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python
+
+import config
+import io
+from pathlib import Path
+import subprocess
+import sys
+import yaml
+
+from enum import Enum
+
+__all__ = ["Timestamp", "Subsystem", "TimestampParser"]
+
+
+class Subsystem(Enum):
+    LIBTEEC = 1
+    LINUXMOD = 2
+    OPTEECORE = 3
+
+
+class Addr2Line(object):
+    def __init__(self, binary):
+        if not (isinstance(config.addr2line, Path) and
+                config.addr2line.is_file()):
+            raise SystemError('addr2line binary was not found')
+        if not (isinstance(binary, Path) and binary.is_file()):
+            raise ValueError(str(binary) + " was not found")
+
+        self.process = subprocess.Popen([str(config.addr2line),
+                                        "-e", str(binary)],
+                                        stdin=subprocess.PIPE,
+                                        stdout=subprocess.PIPE)
+        # and lets use buffered input
+        self.stdin_wrapper = io.TextIOWrapper(self.process.stdin,
+                                              'utf-8')
+
+    def __del__(self):
+        if self.process:
+            self.process.terminate()
+
+    def lookup(self, addr):
+        try:
+            print(hex(addr))
+            self.stdin_wrapper.write(hex(addr) + '\n')
+            self.stdin_wrapper.flush()
+            info = self.process.stdout.readline().decode("utf-8")
+            print(info)
+        except IOError:
+            raise RuntimeError("Can't communicate with addr2line")
+        finally:
+            ret = self.process.poll()
+            if ret:
+                raise RuntimeError(
+                    "addr2line terminated unexpectedly")
+
+        (file, line) = info.rsplit(":", 1)
+
+        if file == "??":
+            raise RuntimeError("Illegal binary file")
+        if line == "0":
+            raise RuntimeError("Illegal line")
+
+        return (file, int(line))
+
+
+class Timestamp(object):
+    """Used to store a timestamp
+
+    Able to parse address of binary file of subsystem and provide
+    actual source file and line
+    """
+    __symbol_parsers = {}
+
+    def __init__(self, core, counter, subsystem, address, payload):
+        self.core = core
+        self.counter = counter
+        if subsystem is not Subsystem:
+            raise TypeError("Wrong subsystem type")
+
+        self.subsystem = subsystem
+        self.address = long(address)
+        self.payload = payload
+
+        self.__parse_addr()
+
+    def __parse_addr(self):
+        if self.address and self.subsystem:
+            if self.subsystem not in self.__symbol_parsers:
+                self.__symbol_parsers[self.subsystem, Addr2Line(
+                    config.subsystem_paths[self.subsystem])]
+
+            (self.filename, self.line) = \
+                self.__symbol_parsers[self.subsystem].lookup(self.address)
+
+        else:
+            raise ValueError('Timestamp address/subsystem isn\'t initialized')
+
+    def __parse_payload(self):
+        raise NotImplementedError
+
+
+class TimestampParser(object):
+    def __init__(self, yaml_path):
+        if not (isinstance(yaml_path, Path) and
+                yaml_path.is_file()):
+            raise ValueError
+
+        self.i = 0
+        self.yaml_path = yaml_path
+        self.doc = yaml.load(open(str(yaml_path), 'r'))
+        self.n = len(self.doc["timestamps"])
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        return self.next()
+
+    def next(self):
+        if self.i >= self.n:
+            raise StopIteration()
+
+        print(self.doc["timestamps"][self.i])
+        self.i += 1
+
+
+if __name__ == '__main__':
+    sys.exit("This source should be used only as a module")


### PR DESCRIPTION
Add initial skelethon of the app for analyzing timestamps dumps. Currently
there are only stubs for different benchmark cases, but added
generic code for working with YAML file, parsing symbols (wrapper
for addr2line), and iterating through the set of timestamps.

Signed-off-by: Igor Opaniuk <igor.opaniuk@linaro.org>