### PR TITLE
benchmark: change ts buffer allocation flow

### DIFF
--- a/benchmark_aux.c
+++ b/benchmark_aux.c
@@ -149,3 +149,50 @@ void *mmap_paddr(intptr_t paddr, uint64_t size)
 	close(devmem);
 	return (hw_addr + offset);
 }
+
+size_t get_library_load_offset(pid_t pid, const char *libname)
+{
+	char path[256];
+	char buf[256];
+	FILE* file;
+	size_t addr = 0;
+	size_t start, end, offset;
+	char flags[4];
+	int len;
+	int len_libname = strlen(libname);
+
+	snprintf(path, sizeof path, "/proc/%d/smaps", pid);
+
+	file = fopen(path, "rt");
+	if (file == NULL)
+		return 0;
+
+	while (fgets(buf, sizeof buf, file) != NULL) {
+		len = strlen(buf);
+		if (len > 0 && buf[len-1] == '\n') {
+		    buf[--len] = '\0';
+		}
+
+		if (len <= len_libname || !strstr(buf, libname)) {
+			continue;
+		}
+
+		printf("%s\n", buf);
+		if (sscanf(buf, "%zx-%zx %c%c%c%c %zx", &start, &end,
+			  &flags[0], &flags[1],
+			  &flags[2], &flags[3], &offset) != 7) {
+			continue;
+		}
+
+		if (flags[0] != 'r' || flags[2] != 'x') {
+			continue;
+		}
+		addr = start - offset;
+		break;
+	}
+
+	fclose(file);
+
+	return addr;
+}
+

--- a/benchmark_aux.h
+++ b/benchmark_aux.h
@@ -43,6 +43,8 @@ void print_line(void);
 void alloc_argv(int argc, char *argv[], char **new_argv[]);
 void dealloc_argv(int new_argc, char **new_argv);
 
+void *mmap_paddr(intptr_t paddr, uint64_t size);
+
 /* get amount of cores */
 uint32_t get_cores(void);
 #endif /* BENCHMARK_AUX_H */

--- a/benchmark_aux.h
+++ b/benchmark_aux.h
@@ -44,6 +44,7 @@ void alloc_argv(int argc, char *argv[], char **new_argv[]);
 void dealloc_argv(int new_argc, char **new_argv);
 
 void *mmap_paddr(intptr_t paddr, uint64_t size);
+size_t get_library_load_offset(pid_t pid, const char *libname);
 
 /* get amount of cores */
 uint32_t get_cores(void);

--- a/common.h
+++ b/common.h
@@ -36,7 +36,7 @@
 
 #ifdef DEBUG
 #define DBG(fmt, args...) printf("[" OUTPUT_APP_PREFIX \
-		"] DEBUG: %s:%d:%s(): " fmt "\n", __FILE__, __LINE__, __func__, ##args)
+	"] DEBUG: %s:%d:%s(): " fmt "\n", __FILE__, __LINE__, __func__, ##args)
 #else
 #define DBG(fmt, args...)
 #endif

--- a/common.h
+++ b/common.h
@@ -74,5 +74,6 @@
 #define RING_BADPARM	-1
 #define RING_NODATA		-2
 
+#define LIBTEEC_NAME	"libteec.so"
 #endif /* COMMON.H */
 

--- a/main.c
+++ b/main.c
@@ -184,27 +184,29 @@ static bool init_emitter(FILE *ts_file)
 	/* Stream start */
 	if (!yaml_stream_start_event_initialize(&event, YAML_UTF8_ENCODING))
 		ERROR_GOTO(emitter_delete,
-				"Failed to initialize YAML stream start event");
+			"Failed to initialize YAML stream start event");
 	if (!yaml_emitter_emit(&emitter, &event))
-		ERROR_GOTO(emitter_delete, "Failed to emit YAML stream start event");
+		ERROR_GOTO(emitter_delete,
+			"Failed to emit YAML stream start event");
 
 	/* Document start */
 	if (!yaml_document_start_event_initialize(&event,
-							NULL, NULL, NULL, YAML_IMPLICIT))
+			NULL, NULL, NULL, YAML_IMPLICIT))
 		ERROR_GOTO(emitter_delete,
-				"Failed to initialize YAML document start event");
+			"Failed to initialize YAML document start event");
 	if (!yaml_emitter_emit(&emitter, &event))
-		ERROR_GOTO(emitter_delete, "Failed to emit YAML doc start event");
+		ERROR_GOTO(emitter_delete,
+			"Failed to emit YAML doc start event");
 
 	/* Mapping start */
 	if (!yaml_mapping_start_event_initialize(&event,
 				NULL, NULL , YAML_IMPLICIT,
 				YAML_ANY_SEQUENCE_STYLE))
 		ERROR_GOTO(emitter_delete,
-				"Failed to initialize YAML mapping start event");
+			"Failed to initialize YAML mapping start event");
 	if (!yaml_emitter_emit(&emitter, &event))
 		ERROR_GOTO(emitter_delete,
-				"Failed to emit YAML sequence mapping event");
+			"Failed to emit YAML sequence mapping event");
 	/* Key timestamps */
 	yaml_scalar_event_initialize(&event, NULL, NULL,
 		(yaml_char_t *)"timestamps", -1, 1, 1, YAML_PLAIN_SCALAR_STYLE);
@@ -216,9 +218,10 @@ static bool init_emitter(FILE *ts_file)
 				NULL, NULL , YAML_IMPLICIT,
 				YAML_ANY_SEQUENCE_STYLE))
 		ERROR_GOTO(emitter_delete,
-				"Failed to initialize YAML sequence start event");
+			"Failed to initialize YAML sequence start event");
 	if (!yaml_emitter_emit(&emitter, &event))
-		ERROR_GOTO(emitter_delete, "Failed to emit YAML sequence start event");
+		ERROR_GOTO(emitter_delete,
+			"Failed to emit YAML sequence start event");
 
 	return true;
 emitter_delete:
@@ -233,31 +236,33 @@ static void deinit_emitter()
 	/* Sequence cmd */
 	if (!yaml_sequence_end_event_initialize(&event))
 		ERROR_GOTO(emitter_delete,
-				"Failed to initialize YAML sequence end event");
+			"Failed to initialize YAML sequence end event");
 	if (!yaml_emitter_emit(&emitter, &event))
-		ERROR_GOTO(emitter_delete, "Failed to emit YAML sequence end event");
+		ERROR_GOTO(emitter_delete,
+			"Failed to emit YAML sequence end event");
 
 	/* Mapping end */
 	if (!yaml_mapping_end_event_initialize(&event))
 		ERROR_GOTO(emitter_delete,
-				"Failed to initialize YAML mapping end event");
+			"Failed to initialize YAML mapping end event");
 	if (!yaml_emitter_emit(&emitter, &event))
 		ERROR_GOTO(emitter_delete,
-				"Failed to emit YAML mapping end event");
+			"Failed to emit YAML mapping end event");
 
 	/* Document end */
 	if (!yaml_document_end_event_initialize(&event, 0))
 		ERROR_GOTO(emitter_delete,
-				"Failed to initialize YAML document end event");
+			"Failed to initialize YAML document end event");
 	if (!yaml_emitter_emit(&emitter, &event))
 		ERROR_GOTO(emitter_delete, "Failed to emit YAML doc end event");
 
 	/* Stream end */
 	if (!yaml_stream_end_event_initialize(&event))
 		ERROR_GOTO(emitter_delete,
-				"Error occured while initialising YAML stream end event");
+			"Failed to initialise YAML stream end event");
 	if (!yaml_emitter_emit(&emitter, &event))
-		ERROR_GOTO(emitter_delete, "Failed to emit YAML stream end event");
+		ERROR_GOTO(emitter_delete,
+			"Failed to emit YAML stream end event");
 
 emitter_delete:
 	yaml_emitter_delete(&emitter);
@@ -290,7 +295,8 @@ static bool fill_timestamp(uint32_t core, uint64_t count, uint64_t addr,
 	if (!yaml_mapping_start_event_initialize(&event,
 				NULL, NULL , YAML_IMPLICIT,
 				YAML_ANY_SEQUENCE_STYLE))
-		ERROR_RETURN_FALSE("Failed to initialize YAML mapping start event");
+		ERROR_RETURN_FALSE(
+			"Failed to initialize YAML mapping start event");
 	if (!yaml_emitter_emit(&emitter, &event))
 		ERROR_RETURN_FALSE("Failed to emit YAML mapping start event");
 
@@ -308,7 +314,8 @@ static bool fill_timestamp(uint32_t core, uint64_t count, uint64_t addr,
 
 	/* Mapping end */
 	if (!yaml_mapping_end_event_initialize(&event))
-		ERROR_RETURN_FALSE("Failed to initialize YAML mapping end event");
+		ERROR_RETURN_FALSE(
+			"Failed to initialize YAML mapping end event");
 	if (!yaml_emitter_emit(&emitter, &event))
 		ERROR_RETURN_FALSE("Failed to emit YAML mapping end event");
 
@@ -341,7 +348,8 @@ static void *ts_consumer(void *arg)
 		ERROR_GOTO(exit, "Can't open timestamp file");
 
 	if (!init_emitter(ts_file))
-		ERROR_GOTO(file_close, "Error occured in emitter initialization");
+		ERROR_GOTO(file_close,
+			"Error occured in emitter initialization");
 
 	while (is_running) {
 		ts_received = false;
@@ -438,7 +446,8 @@ int main(int argc, char *argv[])
 		tsfile_path = malloc(strlen(testapp_path) +
 					strlen(TSFILE_NAME_SUFFIX) + 1);
 		if (!tsfile_path)
-			ERROR_EXIT("Memory allocation failed for timestamp file path.");
+			ERROR_EXIT("Memory allocation failed "
+					"for timestamp file path.");
 
 		tsfile_path[0] = '\0';
 		strcat(tsfile_path, testapp_path);
@@ -459,7 +468,7 @@ int main(int argc, char *argv[])
 		/* wait for our consumer thread terminate */
 		if (pthread_join(consumer_thread, NULL)) {
 			DBG("Error joining thread");
-			ERROR_EXIT("Something went wrong while consuming timestamps");
+			ERROR_EXIT("Couldn't start consuming timestamps");
 		}
 	}
 	else {

--- a/main.c
+++ b/main.c
@@ -46,12 +46,9 @@
 #include "common.h"
 
 #define MAX_SCALAR	20
-static struct tee_ts_global *bench_ts_global;
+static volatile struct tee_ts_global *bench_ts_global;
 
 static const TEEC_UUID pta_benchmark_uuid = PTA_BENCHMARK_UUID;
-static TEEC_SharedMemory ts_buf_shm = {
-		.flags = TEEC_MEM_INPUT | TEEC_MEM_OUTPUT
-};
 static TEEC_Context ctx;
 static TEEC_Session sess;
 
@@ -82,52 +79,42 @@ static void open_bench_pta(void)
 static void close_bench_pta(void)
 {
 	/* release benchmark timestamp shm */
-	TEEC_ReleaseSharedMemory(&ts_buf_shm);
 	TEEC_CloseSession(&sess);
 	TEEC_FinalizeContext(&ctx);
 }
 
-static void init_ts_global(void *ts_global, uint32_t cores)
-{
-	unsigned int i;
-	struct tee_ts_cpu_buf *cpu_buf;
-
-	/* init global timestamp buffer */
-	bench_ts_global = (struct tee_ts_global *)ts_global;
-	bench_ts_global->cores = cores;
-
-	/* init per-cpu timestamp buffers */
-	for (i = 0; i < cores; i++) {
-		cpu_buf = &bench_ts_global->cpu_buf[i];
-		memset(cpu_buf, 0, sizeof(struct tee_ts_cpu_buf));
-	}
-}
-
-static void register_bench_buf(uint32_t cores)
+static void alloc_bench_buf(uint32_t cores)
 {
 	TEEC_Result res;
 	TEEC_Operation op = { 0 };
 	uint32_t ret_orig;
+	intptr_t paddr_ts_buf = 0;
+	size_t size;
 
-	ts_buf_shm.size = sizeof(struct tee_ts_global) +
-			sizeof(struct tee_ts_cpu_buf) * cores;
+	op.paramTypes = TEEC_PARAM_TYPES(TEEC_VALUE_INOUT,
+			TEEC_VALUE_INPUT, TEEC_NONE, TEEC_NONE);
 
-	/* allocate global timestamp buffer */
-	res = TEEC_AllocateSharedMemory(&ctx, &ts_buf_shm);
-	tee_check_res(res, "TEEC_AllocateSharedMemory");
+	op.params[1].value.a = cores;
 
-	init_ts_global(ts_buf_shm.buffer, cores);
-
-	op.paramTypes = TEEC_PARAM_TYPES(TEEC_MEMREF_PARTIAL_INOUT,
-			TEEC_NONE, TEEC_NONE, TEEC_NONE);
-	op.params[0].memref.parent = &ts_buf_shm;
-
-	TEEC_InvokeCommand(&sess, BENCHMARK_CMD_REGISTER_MEMREF,
+	res = TEEC_InvokeCommand(&sess, BENCHMARK_CMD_REGISTER_MEMREF,
 					&op, &ret_orig);
 	tee_check_res(res, "TEEC_InvokeCommand");
+
+	paddr_ts_buf = op.params[0].value.a;
+	size = op.params[0].value.b;
+
+	INFO("ts buffer paddr = %x, size = %d\n", paddr_ts_buf, size);
+	if (paddr_ts_buf) {
+
+		bench_ts_global = mmap_paddr(paddr_ts_buf, size);
+		if (!bench_ts_global)
+			ERROR_EXIT("Failed to allocate timestamp buffer");
+	} else {
+		ERROR_EXIT("Failed to allocate timestamp buffer");
+	}
 }
 
-static void unregister_bench(void)
+static void free_bench_buf(void)
 {
 	TEEC_Result res;
 	TEEC_Operation op = { 0 };
@@ -153,7 +140,7 @@ static void usage(char *progname)
 	fprintf(stderr, "  host_app_args   Original host app args\n");
 }
 
-static int timestamp_pop(struct tee_ts_cpu_buf *cpu_buf,
+static int timestamp_pop(volatile struct tee_ts_cpu_buf *cpu_buf,
 						struct tee_time_st *ts)
 {
 	uint64_t ts_tail;
@@ -358,13 +345,15 @@ static void *ts_consumer(void *arg)
 						&ts_data);
 			if (!ret) {
 				ts_received = true;
-				DBG("Timestamp: core = %u; tick = %lld; pc = 0x%"
-						PRIx64 ";system = %s",
-						i, ts_data.cnt, ts_data.addr,
-						bench_str_src(ts_data.src));
+				DBG("Timestamp: core = %u; tick = %lld; "
+					"pc = 0x%" PRIx64 "; system = %s",
+					i, ts_data.cnt, ts_data.addr,
+					bench_str_src(ts_data.src));
 				if (!fill_timestamp(i, ts_data.cnt,
-						ts_data.addr, bench_str_src(ts_data.src)))
-					ERROR_GOTO(deinit_yaml, "Adding timestamp failed");
+					ts_data.addr,
+					bench_str_src(ts_data.src)))
+					ERROR_GOTO(deinit_yaml,
+					"Adding timestamp failed");
 
 			}
 		}
@@ -375,7 +364,8 @@ static void *ts_consumer(void *arg)
 				sched_yield();
 			} else {
 				ERROR_GOTO(deinit_yaml,
-					"No new data in the per-cpu ringbuffers, closing ts file");
+					"No new data in the per-cpu ringbuffers"
+					", closing ts file");
 			}
 		}
 	}
@@ -424,7 +414,7 @@ int main(int argc, char *argv[])
 
 	INFO("2. Allocating per-core buffers, cores detected = %d",
 					cores);
-	register_bench_buf(cores);
+	alloc_bench_buf(cores);
 
 	res = realpath(argv[1], testapp_path);
 	if (!res)
@@ -480,7 +470,7 @@ int main(int argc, char *argv[])
 	INFO("4. Done benchmark");
 
 	dealloc_argv(argc-1, testapp_argv);
-	unregister_bench();
+	free_bench_buf();
 	close_bench_pta();
 	return 0;
 }


### PR DESCRIPTION
1. Change timestamp buffer allocation/mapping flow
2. Add misc cosmetic fixes

In case if timestamp buffer is allocated in userspace and new register
user memory API is used for its registering in OP-TEE (introduced in
https://github.com/OP-TEE/optee_client/commit/27888d73d156d4862c07effce7c8c2455774768b),
there is no possibility to keep this mapping permanent among different
TEEC_InvokeCommand invocations. All all SHM are automatically unmapped from
OP-TEE VA space after TEEC_InvokeCommand is handled by OP-TEE.

Fixes: https://github.com/OP-TEE/optee_os/issues/1979

`Signed-off-by: Igor Opaniuk <igor.opaniuk@linaro.org>`