### PR TITLE
Fix braking compilation when enabling OP-TEE benchmark.

### DIFF
--- a/main.c
+++ b/main.c
@@ -106,7 +106,7 @@ static void alloc_bench_buf(uint32_t cores)
 	paddr_ts_buf = op.params[0].value.a;
 	size = op.params[0].value.b;
 
-	INFO("ts buffer paddr = %x, size = %d\n", paddr_ts_buf, size);
+	INFO("ts buffer paddr = %" PRIiPTR ", size = %zu\n", paddr_ts_buf, size);
 	if (paddr_ts_buf) {
 
 		bench_ts_global = mmap_paddr(paddr_ts_buf, size);


### PR DESCRIPTION
Improper use of format specifiers for arguments of type `intptr_t` and `size_t`
raise warnings at compile time. Since the build process has by default GCC's `-Werror` flag set, compilation will fail with two errors. This patch resolves issue [#11](https://github.com/linaro-swg/optee_benchmark/issues/11) by using the appropriate format specifiers.