### PR TITLE
docs: Remove current docs and link to the new location

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # optee_benchmark
-OP-TEE Latency benchmark application
+This git contains source code for the benchmark framework for the OP-TEE
+project.
+
+All official OP-TEE documentation has moved to http://optee.readthedocs.io. The
+information that used to be here in this git can be found under
+[optee_benchmark].
+
+// OP-TEE core maintainers
+
+[optee_benchmark]: https://optee.readthedocs.io/building/gits/optee_benchmark.html


### PR DESCRIPTION
All current documentation has been transferred to a new git called
optee_docs [1]. The output from optee_docs will be rendered using Sphinx
and hosted at optee.readthedocs.io [2]. The new documentation git will
also be part of the regular OP-TEE releases. For completeness, it will
also be included in our manifests making up a full OP-TEE developer
setup.

[1] https://github.com/OP-TEE/optee_docs
[2] https://optee.readthedocs.io

Signed-off-by: Joakim Bech <joakim.bech@linaro.org>