### PR TITLE
main: fix enum argument for init_emitter()

### DIFF
--- a/main.c
+++ b/main.c
@@ -170,7 +170,7 @@ static bool init_emitter(FILE *ts_file)
 	/* Mapping start */
 	if (!yaml_mapping_start_event_initialize(&event,
 				NULL, NULL , YAML_IMPLICIT,
-				YAML_ANY_SEQUENCE_STYLE))
+				YAML_ANY_MAPPING_STYLE))
 		ERROR_GOTO(emitter_delete,
 			"Failed to initialize YAML mapping start event");
 	if (!yaml_emitter_emit(&emitter, &event))
@@ -263,7 +263,7 @@ static bool fill_timestamp(uint32_t core, uint64_t count, uint64_t addr,
 	/* Mapping start */
 	if (!yaml_mapping_start_event_initialize(&event,
 				NULL, NULL , YAML_IMPLICIT,
-				YAML_ANY_SEQUENCE_STYLE))
+				YAML_ANY_MAPPING_STYLE))
 		ERROR_RETURN_FALSE(
 			"Failed to initialize YAML mapping start event");
 	if (!yaml_emitter_emit(&emitter, &event))


### PR DESCRIPTION
The function yaml_mapping_start_event_initialize()
takes yaml_mapping_style_t style as last argument:

int yaml_mapping_start_event_initialize(
	yaml_event_t *event,
	const yaml_char_t *anchor,
	const yaml_char_t *tag,
	int implicit,
	yaml_mapping_style_t style)

Use YAML_ANY_MAPPING_STYLE instead of YAML_ANY_SEQUENCE_STYLE. Both have
the same effective value of 0. No functional change.

Fix build error reported by GCC 10 with trace below:

main.c:173:5: error: implicit conversion from ‘enum yaml_sequence_style_e’ to ‘yaml_mapping_style_t’ {aka ‘enum yaml_mapping_style_e’} [-Werror=enum-conversion]
  173 |     YAML_ANY_SEQUENCE_STYLE))
      |     ^~~~~~~~~~~~~~~~~~~~~~~

Link: http://patchwork.ozlabs.org/project/buildroot/patch/20200530171428.562778-1-romain.naour@gmail.com/
Signed-off-by: Romain Naour <romain.naour@gmail.com>
[tweaked commit message and add link]
Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>